### PR TITLE
Fix type mismatch in checking value with mssing value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of tslib
 0.0.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Coerce type of value to type of missVal in PiXmlReader to avoid non
+  equality because of different types.
 
 
 0.0.5 (2014-10-30)

--- a/tslib/readers/pi_xml_reader.py
+++ b/tslib/readers/pi_xml_reader.py
@@ -90,7 +90,7 @@ class PiXmlReader(TimeSeriesReader):
                 t = event.attrib['time']
                 datetimes.append(parse_datetime("{}T{}".format(d, t)))
                 value = event.attrib['value']
-                values.append(value if value != missVal else "NaN")
+                values.append(value if type(missVal)(value) != missVal else "NaN")
                 flags.append(event.attrib.get('flag', None))
                 flag_sources.append(event.attrib.get('flagSource', None))
                 comments.append(event.attrib.get('comment', None))


### PR DESCRIPTION
### Issue
https://github.com/nens/lizard-nxt/issues/750

### Fix
Coerce type of value to check to type of missing value to avoid non equality because of type mismatch.