### PR TITLE
Fix duplicate warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of tslib
 0.0.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Instead of breaking off an import when a duplicate timeseries is
+  encountered, show a warning, ignore the duplicate, and continue.
 
 
 0.0.8 (2019-01-31)

--- a/tslib/readers/pi_xml_reader.py
+++ b/tslib/readers/pi_xml_reader.py
@@ -203,7 +203,7 @@ class PiXmlReader(TimeSeriesReader):
             location_code = header['locationId']
 
             if (series_code, location_code) in duplicate_check_set:
-                logger.warning(
+                logger.info(
                     'PiXML import skipped an entry because of duplicate for '
                     'timeseries_code "%s", location_code "%s" and file "%s".',
                     series_code, location_code, self.source


### PR DESCRIPTION
- Instead of breaking off an import when a duplicate timeseries is
  encountered, show a warning, ignore the duplicate, and continue.

https://nelen-schuurmans.atlassian.net/browse/PROJ-1444